### PR TITLE
Supports pass options to factory definition

### DIFF
--- a/factory.js
+++ b/factory.js
@@ -42,10 +42,10 @@ Factory.build = (name, attributes = {}, options = {}) => {
   // or return a 'fake' _id (since we're not inserting anything)
   const makeRelation = relName => {
     if (options.insert) {
-      return Factory.create(relName)._id;
+      return Factory.create(relName, {}, options)._id;
     }
     if (options.tree) {
-      return Factory.build(relName, {}, {tree: true});
+      return Factory.build(relName, {}, _.extend(options, {tree: true}));
     }
     // fake an id on build
     return Random.id();
@@ -56,10 +56,8 @@ Factory.build = (name, attributes = {}, options = {}) => {
   };
 
   const getValueFromFunction = func => {
-    const api = {
-      sequence: fn => fn(factory.sequence)
-    };
-    const fnRes = func.call(result, api);
+    const api = { sequence: fn => fn(factory.sequence) };
+    const fnRes = func.call(result, api, options);
     return getValue(fnRes);
   };
 
@@ -104,8 +102,8 @@ Factory.build = (name, attributes = {}, options = {}) => {
   return result;
 };
 
-Factory.tree = (name, attributes) => {
-  return Factory.build(name, attributes, {tree: true});
+Factory.tree = (name, attributes, options = {}) => {
+  return Factory.build(name, attributes, _.extend(options, {tree: true}));
 };
 
 Factory._create = (name, doc) => {
@@ -115,8 +113,8 @@ Factory._create = (name, doc) => {
   return record;
 };
 
-Factory.create = (name, attributes = {}) => {
-  const doc = Factory.build(name, attributes, {insert: true});
+Factory.create = (name, attributes = {}, options = {}) => {
+  const doc = Factory.build(name, attributes, _.extend(options, {insert: true}));
   const record = Factory._create(name, doc);
 
   Factory.get(name).afterHooks.forEach(cb => cb(record));

--- a/factory.js
+++ b/factory.js
@@ -31,7 +31,7 @@ Factory.get = name => {
   return factory;
 };
 
-Factory.build = (name, attributes = {}, options = {}) => {
+Factory._build = (name, attributes = {}, userOptions = {}, options = {}) => {
   const factory = Factory.get(name);
   const result = {};
 
@@ -42,10 +42,10 @@ Factory.build = (name, attributes = {}, options = {}) => {
   // or return a 'fake' _id (since we're not inserting anything)
   const makeRelation = relName => {
     if (options.insert) {
-      return Factory.create(relName, {}, options)._id;
+      return Factory.create(relName, {}, userOptions)._id;
     }
     if (options.tree) {
-      return Factory.build(relName, {}, _.extend(options, {tree: true}));
+      return Factory._build(relName, {}, userOptions, {tree: true});
     }
     // fake an id on build
     return Random.id();
@@ -57,7 +57,7 @@ Factory.build = (name, attributes = {}, options = {}) => {
 
   const getValueFromFunction = func => {
     const api = { sequence: fn => fn(factory.sequence) };
-    const fnRes = func.call(result, api, options);
+    const fnRes = func.call(result, api, userOptions);
     return getValue(fnRes);
   };
 
@@ -102,8 +102,12 @@ Factory.build = (name, attributes = {}, options = {}) => {
   return result;
 };
 
-Factory.tree = (name, attributes, options = {}) => {
-  return Factory.build(name, attributes, _.extend(options, {tree: true}));
+Factory.build = (name, attributes = {}, userOptions = {}) => {
+  return Factory._build(name, attributes, userOptions);
+};
+
+Factory.tree = (name, attributes, userOptions = {}) => {
+  return Factory._build(name, attributes, userOptions, {tree: true});
 };
 
 Factory._create = (name, doc) => {
@@ -113,8 +117,8 @@ Factory._create = (name, doc) => {
   return record;
 };
 
-Factory.create = (name, attributes = {}, options = {}) => {
-  const doc = Factory.build(name, attributes, _.extend(options, {insert: true}));
+Factory.create = (name, attributes = {}, userOptions = {}) => {
+  const doc = Factory._build(name, attributes, userOptions, {insert: true});
   const record = Factory._create(name, doc);
 
   Factory.get(name).afterHooks.forEach(cb => cb(record));

--- a/factory_tests.js
+++ b/factory_tests.js
@@ -359,3 +359,38 @@ Tinytest.add("Factory - Tree - Basic", test => {
 
   test.equal(book.author.name, "John Smith");
 });
+
+Tinytest.add("Factory - Build - With options", test => {
+  Factory.define('author', Authors, {
+    name: "John Smith",
+    books(factory, options = { bookCount: 2 }) {
+      return _(options.bookCount).times((n) => `${n + 1} book by ${this.name}`)
+    }
+  });
+
+  const author = Factory.build('author', {}, { bookCount: 3 });
+
+  test.length(author.books, 3);
+  test.equal(author.books, [
+    '1 book by John Smith',
+    '2 book by John Smith',
+    '3 book by John Smith',
+  ]);
+});
+
+Tinytest.add("Factory - Create - With options", test => {
+  Factory.define('book', Books, {
+    name: "A book",
+    pages(factory, options = { pageCount: 2 }) {
+      return _(options.pageCount).times((n) => `Page ${n + 1}`)
+    }
+  });
+
+  const book = Factory.create('book', {}, { pageCount: 2 });
+
+  test.length(book.pages, 2);
+  test.equal(book.pages, [
+    'Page 1',
+    'Page 2',
+  ]);
+});


### PR DESCRIPTION
I really like this meteor package to shape mock data for my tests. As suggested in https://github.com/versolearning/meteor-factory/issues/18, I would also find useful the possibility to pass options to factory definitions, instead of relying on extend factories. This PR implements such feature.

## Example
``` javascript
Factory.define('author', Authors, {
   name: "John Smith",
   books(factory, options = { bookCount: 2 }) {
     return _(options.bookCount).times((n) => `${n + 1} book by ${this.name}`)
   }
});

 // creates tree books to the author
const author = Factory.build('author', {}, { bookCount: 3 });
```