### PR TITLE
Allow nested _id in relationships

### DIFF
--- a/factory.js
+++ b/factory.js
@@ -63,7 +63,7 @@ Factory._build = (name, attributes = {}, userOptions = {}, options = {}) => {
 
   factory.sequence += 1;
 
-  const walk = (record, object) => {
+  const walk = (record, object, isNested) => {
     _.each(object, (value, key) => {
       let newValue = value;
       // is this a Factory instance?
@@ -81,12 +81,12 @@ Factory._build = (name, attributes = {}, userOptions = {}, options = {}) => {
         // if an object literal is passed in, traverse deeper into it
       } else if (Object.prototype.toString.call(value) === "[object Object]") {
         record[key] = record[key] || {};
-        return walk(record[key], value);
+        return walk(record[key], value, true);
       }
 
       const modifier = { $set: {} };
 
-      if (key !== "_id") {
+      if (key !== "_id" || isNested) {
         modifier.$set[key] = newValue;
       }
 
@@ -171,7 +171,7 @@ Factory._buildAsync = async (
 
         const modifier = { $set: {} };
 
-        if (key !== "_id") {
+        if (key !== "_id" || parentKey) {
           const modifierKey = parentKey ? `${parentKey}.${key}` : key;
           modifier.$set[modifierKey] = newValue;
         }

--- a/factory.js
+++ b/factory.js
@@ -171,7 +171,7 @@ Factory._buildAsync = async (
 
         const modifier = { $set: {} };
 
-        if (key !== "_id" || parentKey) {
+        if (key !== "_id" || parentKey) {
           const modifierKey = parentKey ? `${parentKey}.${key}` : key;
           modifier.$set[modifierKey] = newValue;
         }

--- a/factory_tests.js
+++ b/factory_tests.js
@@ -298,7 +298,7 @@ Tinytest.add(
 Tinytest.add("Factory (sync) - Create - Nested _id field", (test) => {
   Factory.define("bookWithAuthor", Books, { authorLink: { _id: "test" } })
 
-  var book = Factory.create("bookWithAuthor");
+  const book = Factory.create("bookWithAuthor");
 
   test.equal(book.authorLink._id, "test")
 });
@@ -311,10 +311,11 @@ Tinytest.add("Factory (sync) - Create - Nested relationship", (test) => {
     { _id: Factory.get("author") },
   });
 
-  var book = Factory.create("bookWithAuthor");
-
+  const book = Factory.create("bookWithAuthor");
+  const author = Authors.findOne({ _id: book.authorLink._id })
+  
   test.isTrue(!!book.authorLink._id);
-  test.equal(book.authorLink._id, Authors.findOne({_id: book.authorLink._id })._id);
+  test.equal(book.authorLink._id, author._id);
 });
 
 Tinytest.add("Factory (sync) - Build - Sequence", (test) => {
@@ -910,15 +911,15 @@ Tinytest.addAsync(
   }
 );
 
-Tinytest.add("Factory (async) - Create - Nested _id field", async (test) => {
+Tinytest.addAsync("Factory (async) - Create - Nested _id field", async (test) => {
   Factory.define("bookWithAuthor", Books, { authorLink: { _id: "test" } })
 
-  var book = await Factory.createAsync("bookWithAuthor");
+  const book = await Factory.createAsync("bookWithAuthor");
 
   test.equal(book.authorLink._id, "test")
 });
 
-Tinytest.add("Factory (async) - Create - Nested relationship", async (test) => {
+Tinytest.addAsync("Factory (async) - Create - Nested relationship", async (test) => {
   Factory.define("author", Authors, {
     name: "John Smith",
   });
@@ -926,10 +927,11 @@ Tinytest.add("Factory (async) - Create - Nested relationship", async (test) => {
     { _id: Factory.get("author") },
   });
 
-  var book = await Factory.create("bookWithAuthor");
-
+  const book = await Factory.create("bookWithAuthor");
+  const author = await Authors.findOneAsync({ _id: book.authorLink._id });
+  
   test.isTrue(!!book.authorLink._id);
-  test.equal(book.authorLink._id, await Authors.findOneAsync({_id: book.authorLink._id })._id);
+  test.equal(book.authorLink._id, author._id);
 });
 
 Tinytest.addAsync("Factory (async) - Tree - Basic", async (test) => {

--- a/factory_tests.js
+++ b/factory_tests.js
@@ -295,6 +295,28 @@ Tinytest.add(
   }
 );
 
+Tinytest.add("Factory (sync) - Create - Nested _id field", (test) => {
+  Factory.define("bookWithAuthor", Books, { authorLink: { _id: "test" } })
+
+  var book = Factory.create("bookWithAuthor");
+
+  test.equal(book.authorLink._id, "test")
+});
+
+Tinytest.add("Factory (sync) - Create - Nested relationship", (test) => {
+  Factory.define("author", Authors, {
+    name: "John Smith",
+  });
+  Factory.define("bookWithAuthor", Books, { authorLink:
+    { _id: Factory.get("author") },
+  });
+
+  var book = Factory.create("bookWithAuthor");
+
+  test.isTrue(!!book.authorLink._id);
+  test.equal(book.authorLink._id, Authors.findOne({_id: book.authorLink._id })._id);
+});
+
 Tinytest.add("Factory (sync) - Build - Sequence", (test) => {
   Factory.define("author", Authors, {
     name: "John Smith",
@@ -887,6 +909,28 @@ Tinytest.addAsync(
     test.equal(foundAuthor.name, "John Smith");
   }
 );
+
+Tinytest.add("Factory (async) - Create - Nested _id field", async (test) => {
+  Factory.define("bookWithAuthor", Books, { authorLink: { _id: "test" } })
+
+  var book = await Factory.createAsync("bookWithAuthor");
+
+  test.equal(book.authorLink._id, "test")
+});
+
+Tinytest.add("Factory (async) - Create - Nested relationship", async (test) => {
+  Factory.define("author", Authors, {
+    name: "John Smith",
+  });
+  Factory.define("bookWithAuthor", Books, { authorLink:
+    { _id: Factory.get("author") },
+  });
+
+  var book = await Factory.create("bookWithAuthor");
+
+  test.isTrue(!!book.authorLink._id);
+  test.equal(book.authorLink._id, await Authors.findOneAsync({_id: book.authorLink._id })._id);
+});
 
 Tinytest.addAsync("Factory (async) - Tree - Basic", async (test) => {
   Factory.define("author", Authors, {


### PR DESCRIPTION
This addresses #11 and #12.

If I have a schema like this:

```js
const bookSchema = new SimpleSchema({
  "authorLink": Object,
  "authorLink._id": String
});
```

I can now create factories that work, because so far they fail:

```js
Factory.define("fac1", Books, { authorLink: {_id: "test" } }) // Factory.create fails because `walk` removes the _id from the object
Factory.define("fac2", Books, { authorLink: {_id: Factory.get("author") } }) // Factory.create fails too
```