### PR TITLE
Fetch the latest version of a record if it has been modified by afterHooks before returning it

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ $ meteor add dburles:factory
   - [create](https://github.com/versolearning/meteor-factory#create)
   - [createAsync](https://github.com/versolearning/meteor-factory#createasync)
   - [extend](https://github.com/versolearning/meteor-factory#extend)
-- [Other](https://github.com/versolearning/meteor-factory#)
+- [Other](https://github.com/versolearning/meteor-factory#other)
 
 ## Examples
 

--- a/factory.js
+++ b/factory.js
@@ -225,6 +225,10 @@ Factory.create = (name, attributes = {}, userOptions = {}) => {
   const record = Factory._create(name, doc);
 
   Factory.get(name).afterHooks.forEach((cb) => cb(record));
+  
+  if (afterHooks.length) {
+    return collection.findOne(record._id);
+  }
 
   return record;
 };
@@ -239,6 +243,10 @@ Factory.createAsync = async (name, attributes = {}, userOptions = {}) => {
       return await cb(record);
     })
   );
+  
+  if (afterHooks.length) {
+    return collection.findOne(record._id);
+  }
 
   return record;
 };

--- a/factory.js
+++ b/factory.js
@@ -226,8 +226,8 @@ Factory.create = (name, attributes = {}, userOptions = {}) => {
 
   Factory.get(name).afterHooks.forEach((cb) => cb(record));
   
-  if (afterHooks.length) {
-    return collection.findOne(record._id);
+  if (Factory.get(name).afterHooks.length) {
+    return Factory.get(name).collection.findOne(record._id);
   }
 
   return record;
@@ -244,8 +244,8 @@ Factory.createAsync = async (name, attributes = {}, userOptions = {}) => {
     })
   );
   
-  if (afterHooks.length) {
-    return collection.findOne(record._id);
+  if (Factory.get(name).afterHooks.length) {
+    return Factory.get(name).collection.findOneAsync(record._id);
   }
 
   return record;

--- a/factory_tests.js
+++ b/factory_tests.js
@@ -330,6 +330,19 @@ Tinytest.add("Factory (sync) - Create - Sequence", (test) => {
   test.equal(foundAuthor2, 1);
 });
 
+Tinytest.add("Factory (sync) - Create - Modified record in after hook", (test) => {
+  Factory.define("author", Authors, {
+    name: "John Smith",
+  }).after(author => {
+    Authors.update(author._id, { $set: { name: "John Doe" } })
+  });
+
+
+  const author = Factory.create("author");
+
+  test.equal(author.name, "John Doe");
+});
+
 Tinytest.add("Factory (sync) - Build - Array with Factory", (test) => {
   Factory.define("author", Authors, {
     name: "John Smith",
@@ -372,6 +385,7 @@ Tinytest.add("Factory (sync) - Build - Array with an object", (test) => {
 
   test.isTrue(book.array[0].objectInArray);
 });
+
 
 // Could possibly make this a feature:
 // Tinytest.add("Factory (sync) - Build - Array with an object containing a function", test => {
@@ -887,6 +901,20 @@ Tinytest.addAsync(
     test.equal(foundAuthor.name, "John Smith");
   }
 );
+
+
+Tinytest.addAsync("Factory (async) - Create - Modified record in after hook", async (test) => {
+  Factory.define("author", Authors, {
+    name: "John Smith",
+  }).after(author => {
+    Authors.update(author._id, { $set: { name: "John Doe" } })
+  });
+
+
+  const author = await Factory.createAsync("author");
+
+  test.equal(author.name, "John Doe");
+});
 
 Tinytest.addAsync("Factory (async) - Tree - Basic", async (test) => {
   Factory.define("author", Authors, {


### PR DESCRIPTION
This is a suggestion for a change that would make `Factory.create` a bit more consistent.

If you modify a new document in your after hooks, it's possible for this package to return you an outdated version of this document. And so instead of returning the old version, if there are any hooks, we refetch and return it instead.