### PR TITLE
Make sure parentKey is added recursively

### DIFF
--- a/factory.js
+++ b/factory.js
@@ -64,6 +64,7 @@ Factory._build = (name, attributes = {}, userOptions = {}, options = {}) => {
   factory.sequence += 1;
 
   const walk = (record, object, parentKey) => {
+    console.log('parentKey:', parentKey);
     Object.keys(object).forEach((key) => {
       const value = object[key];
       let newValue = value;
@@ -82,14 +83,15 @@ Factory._build = (name, attributes = {}, userOptions = {}, options = {}) => {
         newValue = getValueFromFunction(value);
         // if an object literal is passed in, traverse deeper into it
       } else if (Object.prototype.toString.call(value) === "[object Object]") {
-        record[key] = record[key] || {};
-        return walk(record, value, key);
+        const finalKey = parentKey ? `${parentKey}.${key}` : key;
+        return walk(record, value, finalKey);
       }
 
       const modifier = { $set: {} };
 
       if (key !== "_id" || parentKey) {
-        const modifierKey = parentKey ? `${parentKey}.${key}` : key;
+        const finalKey = parentKey ? `${parentKey}.${key}` : key;
+        const modifierKey = finalKey;
         modifier.$set[modifierKey] = newValue;
       }
 
@@ -168,8 +170,8 @@ Factory._buildAsync = async (
         } else if (
           Object.prototype.toString.call(value) === "[object Object]"
         ) {
-          record[key] = record[key] || {};
-          return await walk(record, value, key);
+          const finalKey = parentKey ? `${parentKey}.${key}` : key;
+          return await walk(record, value, finalKey);
         }
 
         const modifier = { $set: {} };

--- a/factory.js
+++ b/factory.js
@@ -64,7 +64,6 @@ Factory._build = (name, attributes = {}, userOptions = {}, options = {}) => {
   factory.sequence += 1;
 
   const walk = (record, object, parentKey) => {
-    console.log('parentKey:', parentKey);
     Object.keys(object).forEach((key) => {
       const value = object[key];
       let newValue = value;

--- a/factory_tests.js
+++ b/factory_tests.js
@@ -469,6 +469,17 @@ Tinytest.add("Factory (sync) - Create - With options", (test) => {
   test.equal(book.pages, ["Page 1", "Page 2"]);
 });
 
+Tinytest.add("Factory (sync) - Create - Deeply nested override", (test) => {
+  Factory.define("book", Books, { name: "A book" });
+
+  const book = Factory.create("book", {
+    nested: { object: { hello: 'world' } },
+  });
+
+  test.equal(book.nested.object.hello, "world")
+  test.equal(book.object, undefined)
+});
+
 /* Begin async tests */
 
 Tinytest.addAsync(
@@ -983,4 +994,15 @@ Tinytest.addAsync("Factory (async) - Tree - Basic", async (test) => {
   const book = await Factory.treeAsync("book");
 
   test.equal(book.author.name, "John Smith");
+});
+
+Tinytest.addAsync("Factory (async) - Create - Deeply nested override", async (test) => {
+  Factory.define("book", Books, { name: "A book" });
+
+  const book = await Factory.createAsync("book", {
+    nested: { object: { hello: 'world' } },
+  });
+
+  test.equal(book.nested.object.hello, "world")
+  test.equal(book.object, undefined)
 });


### PR DESCRIPTION
2nd level objects were added at the root of the document by mistake.

Here's the result of the following factory:

```js
Factory.define("book", Books, { name: "A book" });
const book = Factory.create("book", {
    nested: { object: { hello: 'world' } },
});
```

Before:
```js
book: {
   _id: 'eJCdospYicMibkdJD',
   name: 'A book',
   nested: {},
   object: { hello: 'world' }
}
```

After:
```js
book: {
   _id: 'eJCdospYicMibkdJD',
   name: 'A book',
   nested: { object: { hello: 'world' } },
}
```